### PR TITLE
Headers for CORS for netlify functons 

### DIFF
--- a/components/causes/CausesLayoutSection.vue
+++ b/components/causes/CausesLayoutSection.vue
@@ -287,6 +287,7 @@ const causes = computedAsync(async () => {
               },
       },
     },
+    sort: ["createdAt:desc"],
     pagination: {
       page: currentPage.value,
       pageSize,

--- a/components/home/FeaturedCampaignsSection.vue
+++ b/components/home/FeaturedCampaignsSection.vue
@@ -62,10 +62,10 @@ const causes =
       populate: "*",
       filters: {
         isFeatured: true,
-        isActive: true,
+        // isActive: true,
         isPrivate: false,
         environment:
-          process.env.NODE_ENV !== "production" ? "production" : "development",
+          process.env.NODE_ENV === "production" ? "production" : "development",
       },
       // fields: [
       //   "title",

--- a/functions/process-donation.js
+++ b/functions/process-donation.js
@@ -44,6 +44,7 @@ export const handler = async (event) => {
 
     if (!causeId) {
       return {
+        headers,
         statusCode: 400,
         body: JSON.stringify({ error: "Cause ID is required" }),
       }
@@ -117,6 +118,7 @@ export const handler = async (event) => {
         .catch((error) => {
           if (error.status === 404) {
             return {
+              headers,
               statusCode: 404,
               body: JSON.stringify({ error: "Cause not found" }),
             }
@@ -130,6 +132,7 @@ export const handler = async (event) => {
       // todo: enable monthly donations
 
       return {
+        headers,
         statusCode: 400,
         body: JSON.stringify({ error: "Monthly donations are disabled" }),
       }
@@ -158,6 +161,7 @@ export const handler = async (event) => {
       })
 
       return {
+        headers,
         statusCode: 200,
         body: JSON.stringify({
           subscriptionId: subscription.id,
@@ -202,6 +206,7 @@ export const handler = async (event) => {
       })
 
       return {
+        headers,
         statusCode: 200,
         body: JSON.stringify({
           paymentIntentId: paymentIntent.id,
@@ -213,6 +218,7 @@ export const handler = async (event) => {
     console.log("Error:", error)
 
     return {
+      headers,
       statusCode: 400,
       body: JSON.stringify({ error: error.message }),
     }

--- a/pages/blogs/index.vue
+++ b/pages/blogs/index.vue
@@ -14,32 +14,42 @@
         and the potential for positive change.
       </p>
       <div class="grid gap-4 mt-8 sm:grid-cols-2 xl:grid-cols-3">
-        <div
-          class="p-4 transition-all rounded-lg group hover:shadow-lg"
-          v-for="(blog, index) in blogs"
-          :key="index"
-        >
-          <NuxtLink :to="`/blogs/${blog.documentId}`">
-            <div class="overflow-hidden h-80">
-              <img
-                :src="blog.image.formats.medium.url"
-                class="object-cover w-full h-full rounded-xl"
-              />
-            </div>
-            <div class="mt-1 group-hover:underline">
-              <h2 class="text-2xl font-normal text-foreground">
-                {{ blog.title }}
-              </h2>
-              <p class="text-sm text-dark-gray">
-                {{ formateDayMonthYear(blog.createdAt) }}
-              </p>
-            </div>
-          </NuxtLink>
-        </div>
+        <template v-if="blogs.length === 0">
+          <div class="w-full h-96 sm:col-span-2 xl:col-span-3">
+            <h2 class="my-32 font-light text-center text-gray-400">
+              Sorry, nothing found :(
+            </h2>
+          </div>
+        </template>
+        <template v-else>
+          <div
+            class="p-4 transition-all rounded-lg group hover:shadow-lg"
+            v-for="(blog, index) in blogs"
+            :key="index"
+          >
+            <NuxtLink :to="`/blogs/${blog.documentId}`">
+              <div class="overflow-hidden h-80">
+                <img
+                  :src="blog.image.formats.medium.url"
+                  class="object-cover w-full h-full rounded-xl"
+                />
+              </div>
+              <div class="mt-1 group-hover:underline">
+                <h2 class="text-2xl font-normal text-foreground">
+                  {{ blog.title }}
+                </h2>
+                <p class="text-sm text-dark-gray">
+                  {{ formateDayMonthYear(blog.createdAt) }}
+                </p>
+              </div>
+            </NuxtLink>
+          </div>
+        </template>
       </div>
 
       <div class="w-full">
         <Button
+          v-if="blogs.length > 0"
           :disabled="buttonDisabled || buttonIsLoading"
           @click="fetchBlogs"
           :variant="'white'"


### PR DESCRIPTION
This pull request includes several changes to different parts of the codebase, focusing on adding headers to responses, modifying sorting and filtering logic, and improving the user interface for the blogs page.

### API Response Improvements:
* [`functions/process-donation.js`](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R47): Added `headers` to various response objects to ensure consistent response headers are included in all API responses. [[1]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R47) [[2]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R121) [[3]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R135) [[4]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R164) [[5]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R209) [[6]](diffhunk://#diff-bb6d3d7dc15769a2c18f72146d0fde93665a15d50bc10d64bdf351c3586f02c3R221)

### Sorting and Filtering Updates:
* [`components/causes/CausesLayoutSection.vue`](diffhunk://#diff-aa355c0c8c6687841f7721a51cbb2b3d8775991388bd1ab84653732364b71172R290): Added sorting by `createdAt` in descending order to the `causes` computed property.
* [`components/home/FeaturedCampaignsSection.vue`](diffhunk://#diff-e3971e93b6f2ace11f4e6fcc4f6cc0935351802045d75f38f90f50968b65511bL65-R68): Commented out the `isActive` filter and adjusted the environment filter logic for featured campaigns.

### User Interface Enhancements:
* [`pages/blogs/index.vue`](diffhunk://#diff-20ad7f0b7201376792cab8cd8bd99b1362546d716b46d73af85a4f7064da95b7R17-R24): Added a template to display a message when no blogs are found and conditionally rendered the "Load More" button only when there are blogs to display. [[1]](diffhunk://#diff-20ad7f0b7201376792cab8cd8bd99b1362546d716b46d73af85a4f7064da95b7R17-R24) [[2]](diffhunk://#diff-20ad7f0b7201376792cab8cd8bd99b1362546d716b46d73af85a4f7064da95b7R47-R52)